### PR TITLE
Feat: 프로필 화면 초기 구현 #21

### DIFF
--- a/cliary/cliary.xcodeproj/project.pbxproj
+++ b/cliary/cliary.xcodeproj/project.pbxproj
@@ -16,6 +16,14 @@
 		A875D17A2C1180BB00489207 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A875D1792C1180BB00489207 /* Assets.xcassets */; };
 		A875D17D2C1180BB00489207 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = A875D17C2C1180BB00489207 /* Base */; };
 		A875D1932C11929F00489207 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A875D1922C11929F00489207 /* TabBarViewController.swift */; };
+		CC9DF1E52C31310400B8D2EE /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1E42C31310400B8D2EE /* ProfileViewController.swift */; };
+		CC9DF1E82C31319700B8D2EE /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1E72C31319700B8D2EE /* BaseViewController.swift */; };
+		CC9DF1EC2C31349D00B8D2EE /* Literal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1EB2C31349D00B8D2EE /* Literal.swift */; };
+		CC9DF1EE2C313B0200B8D2EE /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1ED2C313B0100B8D2EE /* BaseView.swift */; };
+		CC9DF1F02C313B9800B8D2EE /* BaseStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1EF2C313B9800B8D2EE /* BaseStackView.swift */; };
+		CC9DF1F32C313D4300B8D2EE /* ContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1F22C313D4300B8D2EE /* ContainerView.swift */; };
+		CC9DF1F72C31415D00B8D2EE /* RootViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1F62C31415D00B8D2EE /* RootViewProtocol.swift */; };
+		CC9DF1F92C3141A400B8D2EE /* ProfileRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DF1F82C3141A400B8D2EE /* ProfileRootView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +36,14 @@
 		A875D17C2C1180BB00489207 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A875D17E2C1180BB00489207 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A875D1922C11929F00489207 /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
+		CC9DF1E42C31310400B8D2EE /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		CC9DF1E72C31319700B8D2EE /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		CC9DF1EB2C31349D00B8D2EE /* Literal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Literal.swift; sourceTree = "<group>"; };
+		CC9DF1ED2C313B0100B8D2EE /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
+		CC9DF1EF2C313B9800B8D2EE /* BaseStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseStackView.swift; sourceTree = "<group>"; };
+		CC9DF1F22C313D4300B8D2EE /* ContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerView.swift; sourceTree = "<group>"; };
+		CC9DF1F62C31415D00B8D2EE /* RootViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewProtocol.swift; sourceTree = "<group>"; };
+		CC9DF1F82C3141A400B8D2EE /* ProfileRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRootView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,6 +86,7 @@
 		A875D16F2C1180B900489207 /* cliary */ = {
 			isa = PBXGroup;
 			children = (
+				CC9DF1E92C31348500B8D2EE /* Utility */,
 				A875D1842C11841300489207 /* App */,
 				A875D18F2C1191E600489207 /* Presenter */,
 				A875D1792C1180BB00489207 /* Assets.xcassets */,
@@ -91,6 +108,9 @@
 		A875D18F2C1191E600489207 /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
+				CC9DF1F12C313CBF00B8D2EE /* Reusable */,
+				CC9DF1E62C31318800B8D2EE /* Base */,
+				CC9DF1E32C3130E300B8D2EE /* Profile */,
 				A81F68CC2C13055200FAC237 /* Navigation */,
 				A875D1902C11926000489207 /* Auth */,
 				A875D1912C11927300489207 /* TabBar */,
@@ -112,6 +132,58 @@
 				A875D1922C11929F00489207 /* TabBarViewController.swift */,
 			);
 			path = TabBar;
+			sourceTree = "<group>";
+		};
+		CC9DF1E32C3130E300B8D2EE /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				CC9DF1F42C31411000B8D2EE /* View */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		CC9DF1E62C31318800B8D2EE /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				CC9DF1E72C31319700B8D2EE /* BaseViewController.swift */,
+				CC9DF1ED2C313B0100B8D2EE /* BaseView.swift */,
+				CC9DF1EF2C313B9800B8D2EE /* BaseStackView.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		CC9DF1E92C31348500B8D2EE /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				CC9DF1F52C31414D00B8D2EE /* Protocols */,
+				CC9DF1EB2C31349D00B8D2EE /* Literal.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
+		CC9DF1F12C313CBF00B8D2EE /* Reusable */ = {
+			isa = PBXGroup;
+			children = (
+				CC9DF1F22C313D4300B8D2EE /* ContainerView.swift */,
+			);
+			path = Reusable;
+			sourceTree = "<group>";
+		};
+		CC9DF1F42C31411000B8D2EE /* View */ = {
+			isa = PBXGroup;
+			children = (
+				CC9DF1E42C31310400B8D2EE /* ProfileViewController.swift */,
+				CC9DF1F82C3141A400B8D2EE /* ProfileRootView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		CC9DF1F52C31414D00B8D2EE /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				CC9DF1F62C31415D00B8D2EE /* RootViewProtocol.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -192,10 +264,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC9DF1E52C31310400B8D2EE /* ProfileViewController.swift in Sources */,
 				A875D1932C11929F00489207 /* TabBarViewController.swift in Sources */,
+				CC9DF1F02C313B9800B8D2EE /* BaseStackView.swift in Sources */,
 				A875D1752C1180B900489207 /* LoginViewController.swift in Sources */,
+				CC9DF1F92C3141A400B8D2EE /* ProfileRootView.swift in Sources */,
 				A81F68CD2C13055300FAC237 /* NavigationController.swift in Sources */,
 				A875D1712C1180B900489207 /* AppDelegate.swift in Sources */,
+				CC9DF1F72C31415D00B8D2EE /* RootViewProtocol.swift in Sources */,
+				CC9DF1EC2C31349D00B8D2EE /* Literal.swift in Sources */,
+				CC9DF1EE2C313B0200B8D2EE /* BaseView.swift in Sources */,
+				CC9DF1E82C31319700B8D2EE /* BaseViewController.swift in Sources */,
+				CC9DF1F32C313D4300B8D2EE /* ContainerView.swift in Sources */,
 				A875D1732C1180B900489207 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/cliary/cliary/Assets.xcassets/Colors/Contents.json
+++ b/cliary/cliary/Assets.xcassets/Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cliary/cliary/Assets.xcassets/Colors/customBlack.colorset/Contents.json
+++ b/cliary/cliary/Assets.xcassets/Colors/customBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cliary/cliary/Assets.xcassets/Colors/customGray.colorset/Contents.json
+++ b/cliary/cliary/Assets.xcassets/Colors/customGray.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0x2B",
+          "red" : "0x2B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0x2B",
+          "red" : "0x2B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/cliary/cliary/Assets.xcassets/Colors/customPrimary.colorset/Contents.json
+++ b/cliary/cliary/Assets.xcassets/Colors/customPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB0",
+          "green" : "0x16",
+          "red" : "0x37"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB0",
+          "green" : "0x16",
+          "red" : "0x37"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cliary/cliary/Assets.xcassets/Colors/customSecondary.colorset/Contents.json
+++ b/cliary/cliary/Assets.xcassets/Colors/customSecondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0x3D",
+          "red" : "0x68"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0x3D",
+          "red" : "0x68"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cliary/cliary/Assets.xcassets/Colors/customTertiary.colorset/Contents.json
+++ b/cliary/cliary/Assets.xcassets/Colors/customTertiary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC5",
+          "green" : "0xD8",
+          "red" : "0x25"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC5",
+          "green" : "0xD8",
+          "red" : "0x25"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cliary/cliary/Presenter/Base/BaseStackView.swift
+++ b/cliary/cliary/Presenter/Base/BaseStackView.swift
@@ -1,0 +1,23 @@
+//
+//  BaseStackView.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import UIKit
+
+class BaseStackView: UIStackView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configure()
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure() {}
+}

--- a/cliary/cliary/Presenter/Base/BaseView.swift
+++ b/cliary/cliary/Presenter/Base/BaseView.swift
@@ -1,0 +1,26 @@
+//
+//  BaseView.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import UIKit
+
+class BaseView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configure()
+        self.configureHierarchy()
+        self.configureLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure() {} // ex) self.backgroundColor = .black
+    func configureHierarchy() {} // addSubview
+    func configureLayout() {} // SnapKit makeConstraint
+}

--- a/cliary/cliary/Presenter/Base/BaseViewController.swift
+++ b/cliary/cliary/Presenter/Base/BaseViewController.swift
@@ -1,0 +1,50 @@
+//
+//  BaseViewController.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import UIKit
+import Then
+class BaseViewController<ContentView: UIView>: UIViewController {
+    
+    let contentView: ContentView
+    
+    init(contentView: ContentView) {
+        self.contentView = contentView
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        self.view = contentView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureNavigationBar()
+        self.view.backgroundColor = .customBlack
+    }
+}
+
+extension BaseViewController {
+    private func configureNavigationBar() {
+        guard let rootView = self.contentView as? RootViewProtocol else {
+            print("RootViewProtocol을 채택하지 않은 View가 들어옴")
+            return
+        }
+        
+        let appearence = UINavigationBarAppearance()
+        
+        appearence.titleTextAttributes = [.foregroundColor: UIColor.white,  .font: UIFont.systemFont(ofSize: 19, weight: .heavy)]
+        appearence.configureWithTransparentBackground()
+        self.navigationController?.navigationBar.standardAppearance = appearence
+        self.navigationController?.navigationBar.scrollEdgeAppearance = appearence
+        self.navigationItem.title = rootView.navigationTitle
+    }
+}

--- a/cliary/cliary/Presenter/Profile/View/ProfileRootView.swift
+++ b/cliary/cliary/Presenter/Profile/View/ProfileRootView.swift
@@ -1,0 +1,16 @@
+//
+//  ProfileRootView.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ProfileRootView: BaseView, RootViewProtocol {
+    let navigationTitle = Literal.NavigationTitle.profile.rawValue
+    
+    
+}

--- a/cliary/cliary/Presenter/Profile/View/ProfileViewController.swift
+++ b/cliary/cliary/Presenter/Profile/View/ProfileViewController.swift
@@ -1,0 +1,14 @@
+//
+//  ProfileViewController.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import UIKit
+
+final class ProfileViewController: BaseViewController<ProfileRootView> {
+    override init(contentView: ProfileRootView) {
+        super.init(contentView: contentView)
+    }
+}

--- a/cliary/cliary/Presenter/Reusable/ContainerView.swift
+++ b/cliary/cliary/Presenter/Reusable/ContainerView.swift
@@ -1,0 +1,16 @@
+//
+//  ContainerView.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import Foundation
+
+class ContainerView: BaseView {
+    override func configure() {
+        self.backgroundColor = .customGray
+        self.layer.cornerRadius = 15
+        self.clipsToBounds = true
+    }
+}

--- a/cliary/cliary/Presenter/TabBar/TabBarViewController.swift
+++ b/cliary/cliary/Presenter/TabBar/TabBarViewController.swift
@@ -14,13 +14,11 @@ class TabBarViewController: UITabBarController {
         super.viewDidLoad()
 
         configureTabBarViewController()
+        configureAppearence()
     }
     
     // TODO: - Design should be adopted.
     private func configureTabBarViewController() {
-        self.view.backgroundColor = .white
-        self.tabBar.backgroundColor = .systemBackground
-
         self.viewControllers = Tab.allCases.map {
             let tab = $0
             let (title, icon, selectedIcon) = tab.itemResource
@@ -30,6 +28,18 @@ class TabBarViewController: UITabBarController {
                 $0.navigationBar.isHidden = tab == .camera
             }
         }
+    }
+    
+    private func configureAppearence() {
+        let appearence = UITabBarAppearance()
+        
+        appearence.configureWithOpaqueBackground()
+        appearence.shadowColor = .lightGray
+        appearence.backgroundColor = .customBlack
+        self.tabBar.standardAppearance = appearence
+        self.tabBar.scrollEdgeAppearance = appearence
+        self.tabBar.tintColor = .customPrimary
+        self.tabBar.unselectedItemTintColor = .customGray
     }
 }
 
@@ -47,7 +57,7 @@ extension TabBarViewController {
             case .camera:
                 UIViewController().then { $0.view.backgroundColor = .green }
             case .profile:
-                UIViewController().then { $0.view.backgroundColor = .blue }
+                ProfileViewController(contentView: ProfileRootView())
             }
         }
         

--- a/cliary/cliary/Utility/Literal.swift
+++ b/cliary/cliary/Utility/Literal.swift
@@ -1,0 +1,43 @@
+//
+//  Literal.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import Foundation
+
+enum Literal {
+    enum NavigationTitle: String {
+        case profile = "프로필"
+    }
+    
+    enum Profile {
+        enum MonthlyPrimaryLog: String {
+            case totalTime = "운동 시간"
+            case attendance = "출석"
+            case completionRate = "완등률"
+        }
+        
+        enum MonthlySecondaryLog {
+            // 추후 변경
+            enum userLevelComment: String {
+                case yellow = "초급"
+                case green = "도전자"
+                case blue = "중급자"
+                case red = "숙련자"
+                case purple = "보라이머 일 수도...?"
+                case black = "모험가"
+            }
+            
+            var title: String {
+                return "내가 잡은 홀드는?"
+            }
+        }
+        
+        enum MonthlyTertiaryLog: String {
+            case mostVisited = "이번 달 베스트 암장"
+            case firstClear = "난이도 별 도달 날짜"
+        }
+    }
+}

--- a/cliary/cliary/Utility/Protocols/RootViewProtocol.swift
+++ b/cliary/cliary/Utility/Protocols/RootViewProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  RootViewProtocol.swift
+//  cliary
+//
+//  Created by Jinyoung Yoo on 6/30/24.
+//
+
+import Foundation
+
+protocol RootViewProtocol {
+    var navigationTitle: String { get }
+}


### PR DESCRIPTION
# Related Issue
resolve #21

 # Features
- Color Asset 추가
<img width="234" alt="스크린샷 2024-06-30 오후 6 28 23" src="https://github.com/c-r-u-x/crux-iOS/assets/60279483/463c7530-241f-4624-ab25-d27d40620dfc">

- BaseViewController 및 BaseView 생성
  - [x] 9bb286d3bea42b65d21ce5dd0fa9baa09ee5f60d
- 문자열 리터럴들을 한번에 관리할 수 있는 enum 타입 구성
  -  [x] af33124146c8d1ff74fbfe2400234eec359f4199 참고
- BaseVC와 BaseView를 활용하여 프로필 화면 초기 모습 생성/ TabBar Appearance 설정
<img width="200" alt="스크린샷 2024-06-30 오후 6 25 39" src="https://github.com/c-r-u-x/crux-iOS/assets/60279483/7f57be1b-608d-40dd-934d-a7a268c4aaf0">

   - [x] BaseVC 및 BaseView 활용 코드는 6f2ee1fb1f7b3ee89905e8d582234cf32dcb88c2 코멘트 참고
   - [x] BaseVC의 서브클래스 VC 생성 코드는 66caa893b0c497e41358c2068213bc2d30a2d02d 의 코멘트 참고

-  아래 그림과 같은 회색 곡선 뷰를 ContainerView라 네이밍하고 재사용할 수 있게 생성 -> ContainerView를 상속받아서 사용
<img width="200" alt="스크린샷 2024-06-30 오후 6 49 04" src="https://github.com/c-r-u-x/crux-iOS/assets/60279483/4a3a599e-90a6-4838-b70a-65c790735dc5">